### PR TITLE
user supplied options should overwrite defaults

### DIFF
--- a/src/coffee/card.coffee
+++ b/src/coffee/card.coffee
@@ -58,7 +58,7 @@ class Card
       nameDisplay: '.name'
 
   constructor: (el, opts) ->
-    @options = $.extend({}, opts, @defaults)
+    @options = $.extend({}, @defaults, opts)
     @$el = if $(el).is('form') then $(el) else $(el).find 'form'
 
     unless @options.container


### PR DESCRIPTION
See http://api.jquery.com/jquery.extend/ -- Basically the user provided options should be the last arg of the extend call so they "win"

Closes #13 if marged
