### PR TITLE
Fixes JS parsing error in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $('form').card({
     nameInput: 'input#name', // optional - defaults input[name="name"]
 
     width: 200, // optional — default 350px
-    formatting: true // optional - default true
+    formatting: true, // optional - default true
 
     // Strings for translation - optional
     messages: {


### PR DESCRIPTION
I couldn't help but notice that the README contains a Javascript syntax error, this pull request fixes it.

Its a small pull request, but it helps :) Great repo by the way.
