### PR TITLE
Allows dot, hyphen and apostrophes to be entered into the name field.

### DIFF
--- a/lib/js/card.js
+++ b/lib/js/card.js
@@ -504,6 +504,7 @@
 
 },{}],2:[function(_dereq_,module,exports){
 var $, Card,
+  __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
   __slice = [].slice;
 
 _dereq_('jquery.payment');
@@ -749,9 +750,11 @@ Card = (function() {
       }
     },
     captureName: function($el, e) {
-      var banKeyCodes;
+      var allowedSymbols, banKeyCodes, keyCode;
+      keyCode = e.which || e.keyCode;
       banKeyCodes = [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 106, 107, 109, 110, 111, 186, 187, 188, 189, 190, 191, 192, 219, 220, 221, 222];
-      if (banKeyCodes.indexOf(e.which || e.keyCode) !== -1) {
+      allowedSymbols = [189, 109, 190, 110, 222];
+      if (banKeyCodes.indexOf(keyCode) !== -1 && !(!e.shiftKey && __indexOf.call(allowedSymbols, keyCode) >= 0)) {
         return e.preventDefault();
       }
     }

--- a/src/coffee/card.coffee
+++ b/src/coffee/card.coffee
@@ -213,8 +213,21 @@ class Card
       return unless val.month or val.year
       e.preventDefault() if !$.payment.validateCardExpiry(val.month, val.year)
     captureName: ($el, e) ->
+      keyCode = e.which or e.keyCode
       banKeyCodes = [48,49,50,51,52,53,54,55,56,57,106,107,109,110,111,186,187,188,189,190,191,192,219,220,221,222]
-      e.preventDefault() if banKeyCodes.indexOf(e.which or e.keyCode) != -1
+
+      # Allow special symbols:
+      #   - hyphen
+      #   - dot
+      #   - apostrophe
+      allowedSymbols = [
+        189, 109 # hyphen (when not using shiftKey)
+        190, 110 # dot (when not using shiftKey)
+        222 # apostrophe (when not using shiftKey)
+      ]
+
+      if banKeyCodes.indexOf(keyCode) != -1 and not (!e.shiftKey and keyCode in allowedSymbols)
+        e.preventDefault()
 
   $.fn.bindVal = (out, opts={}) ->
     opts.fill = opts.fill || false


### PR DESCRIPTION
Checks the `keyCode` and whether the `shiftKey` is pressed, then _—if shiftKey is not pressed—_ allows select, otherwise banned, keyCodes through to the input field.

This should allow for the entry of:
1. **Hyphen**: `-` but not `_` _(`shift` + `-`)_
2. **Dot**: `.` but not `>` _(`shift` + `.`)_
3. **Apostrophe**: `'` but not `"` _(`shift` + `'`)_
