### PR TITLE
Add "line-height: 1" to card selector

### DIFF
--- a/lib/css/card.css
+++ b/lib/css/card.css
@@ -216,6 +216,7 @@
 
 .card {
   font-family: "Helvetica Neue";
+  line-height: 1;
   position: relative;
   width: 100%;
   height: 100%;

--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -22,6 +22,7 @@
 
 .card {
     font-family: $card-font-family;
+    line-height: 1;
     position: relative;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
I noticed that some of the formatting of the card elements breaks if any parent of .card has a line-height to  set to anything but 1. Adding a line-height of 1 to the .card wrapper seems to fix this.
