### PR TITLE
Fix for IE10 AmEx Flip

### DIFF
--- a/src/scss/browsers/_ie-10.scss
+++ b/src/scss/browsers/_ie-10.scss
@@ -26,3 +26,6 @@
         }
     }
 }
+.card.ie-10.amex .back {
+    display: none;
+}


### PR DESCRIPTION
Fix for AmEx flipping (shouldn't flip - display none for .back)
