### PR TITLE
Make identified card have more neutral background.

### DIFF
--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -248,10 +248,11 @@
 
     &.identified {
         box-shadow: 0 0 20px rgba(0,0,0,0.3);
-        background-color: #000;
-        background-color: rgba(0, 0, 0, 0.5);
 
         .front, .back {
+            background-color: #000;
+            background-color: rgba(0, 0, 0, 0.5);
+
             &:before {
                 @include transition(all $card-transition-time ease);
                 @include card-texture();


### PR DESCRIPTION
The outside curved edges of the card have a visible white residue when
the card is used on a dark background. Adding a black background when
the card is identified makes it look more full. Uses opacity of 50% with a fallback of no opacity for ancient browsers.
