### PR TITLE
Add missing 'main' section to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "card",
   "version": "0.1.3",
   "author": "Jesse Pollak <jpollak92@gmail.com>",
+  "main": "lib/js/card.js",
   "description": "Card let's you add an interactive, CSS3 credit card animation to your credit card form to help your users through the process.",
   "contributors": [
     {


### PR DESCRIPTION
Allows card to be loaded via require('card') ). Fixes #125.
