### PR TITLE
Fixes problem with multiple card forms on the page

### DIFF
--- a/lib/js/card.js
+++ b/lib/js/card.js
@@ -325,7 +325,7 @@
     if (hasTextSelected($target)) {
       return;
     }
-    value = ($target.val() + digit).replace(/\D/g, '');
+    value = ($target.val() + digit).replace(/[\D\s]/g, '');
     card = cardFromNumber(value);
     if (card) {
       return value.length <= card.length[card.length.length - 1];

--- a/lib/js/card.js
+++ b/lib/js/card.js
@@ -631,7 +631,7 @@ Card = (function() {
       console.log("Please provide a container");
       return;
     }
-    this.$container = $(this.options.container);
+    this.$container = this.$el.find(this.options.container);
     this.render();
     this.attachHandlers();
     this.handleInitialValues();


### PR DESCRIPTION
When there were multiple card forms on the page at the same time, it was
rendering the template multiple times in each container. This change
sets the container to be only child elements of the form, so that the
correct number of renders happen in the form.