### PR TITLE
Change name of `values` initializer to `placeholders`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ var card = new Card({
         monthYear: 'mm/yyyy', // optional - default 'month/year'
     },
 
-    // Default values for rendered fields - optional
-    values: {
+    // Default placeholders for rendered fields - optional
+    placeholders: {
         number: '•••• •••• •••• ••••',
         name: 'Full Name',
         expiry: '••/••',
@@ -64,7 +64,7 @@ If you're using npm, you can install card.js with:
     // The current card.js code does not explictly require jQuery, but instead uses the global, so this line is needed.
     window.jQuery = $;
     var card = require("card");
-    
+
 ### Using multiple inputs for one field
 
 Card can be used in forms where you have multiple inputs that render to a single field (i.e. you have a first and last name input). To use Card with this functionality, just pass in a selector that selects the fields in the correct order. For example,
@@ -85,7 +85,7 @@ Card can be used in forms where you have multiple inputs that render to a single
 var card = new Card({
     form: 'form',
     container: '.card-wrapper',
-    
+
     formSelectors: {
         nameInput: 'input[name="first-name"], input[name="last-name"]'
     }
@@ -95,9 +95,9 @@ var card = new Card({
 </html>
 ```
 
-### Rendering with different initial card values
+### Rendering with different initial card placeholders
 
-Card renders with default values for card `name`, `number`, `expiry`, and `cvc`. To override these values, you can pass in a `values` object.
+Card renders with default placeholders for card `name`, `number`, `expiry`, and `cvc`. To override these placeholders, you can pass in a `placeholders` object.
 
 ```html
 <html>
@@ -116,9 +116,9 @@ var card = new Card({
     form: 'form',
     container: '.card-wrapper',
 
-    // passing in a messages object is another way to 
-    // override the default card values
-    values: {
+    // passing in a messages object is another way to
+    // override the default card placeholders
+    placeholders: {
         number: '**** **** **** ****',
         name: 'Arya Stark',
         expiry: '**/****',
@@ -151,7 +151,7 @@ var card = new Card({
     form: 'form',
     container: '.card-wrapper',
 
-    // passing in a messages object is another way to 
+    // passing in a messages object is another way to
     // override the default field names
     messages: {
         validDate: 'expire\ndate',
@@ -182,7 +182,7 @@ $('form').card({
 
     // all of the other options from above
 });
-   
+
 ```
 ## Using with Ember.js or Angular.js
 

--- a/lib/js/card.js
+++ b/lib/js/card.js
@@ -1,4 +1,92 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+module.exports = require('./lib/extend');
+
+
+},{"./lib/extend":2}],2:[function(require,module,exports){
+/*!
+ * node.extend
+ * Copyright 2011, John Resig
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ * http://jquery.org/license
+ *
+ * @fileoverview
+ * Port of jQuery.extend that actually works on node.js
+ */
+var is = require('is');
+
+function extend() {
+  var target = arguments[0] || {};
+  var i = 1;
+  var length = arguments.length;
+  var deep = false;
+  var options, name, src, copy, copy_is_array, clone;
+
+  // Handle a deep copy situation
+  if (typeof target === 'boolean') {
+    deep = target;
+    target = arguments[1] || {};
+    // skip the boolean and the target
+    i = 2;
+  }
+
+  // Handle case when target is a string or something (possible in deep copy)
+  if (typeof target !== 'object' && !is.fn(target)) {
+    target = {};
+  }
+
+  for (; i < length; i++) {
+    // Only deal with non-null/undefined values
+    options = arguments[i]
+    if (options != null) {
+      if (typeof options === 'string') {
+          options = options.split('');
+      }
+      // Extend the base object
+      for (name in options) {
+        src = target[name];
+        copy = options[name];
+
+        // Prevent never-ending loop
+        if (target === copy) {
+          continue;
+        }
+
+        // Recurse if we're merging plain objects or arrays
+        if (deep && copy && (is.hash(copy) || (copy_is_array = is.array(copy)))) {
+          if (copy_is_array) {
+            copy_is_array = false;
+            clone = src && is.array(src) ? src : [];
+          } else {
+            clone = src && is.hash(src) ? src : {};
+          }
+
+          // Never move original objects, clone them
+          target[name] = extend(deep, clone, copy);
+
+        // Don't bring in undefined values
+        } else if (typeof copy !== 'undefined') {
+          target[name] = copy;
+        }
+      }
+    }
+  }
+
+  // Return the modified object
+  return target;
+};
+
+/**
+ * @public
+ */
+extend.version = '1.1.3';
+
+/**
+ * Exports module.
+ */
+module.exports = extend;
+
+
+},{"is":3}],3:[function(require,module,exports){
 
 /**!
  * is
@@ -762,95 +850,7 @@ is.symbol = function (value) {
   return typeof Symbol === 'function' && toStr.call(value) === '[object Symbol]' && typeof symbolValueOf.call(value) === 'symbol';
 };
 
-},{}],2:[function(require,module,exports){
-module.exports = require('./lib/extend');
-
-
-},{"./lib/extend":3}],3:[function(require,module,exports){
-/*!
- * node.extend
- * Copyright 2011, John Resig
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- *
- * @fileoverview
- * Port of jQuery.extend that actually works on node.js
- */
-var is = require('is');
-
-function extend() {
-  var target = arguments[0] || {};
-  var i = 1;
-  var length = arguments.length;
-  var deep = false;
-  var options, name, src, copy, copy_is_array, clone;
-
-  // Handle a deep copy situation
-  if (typeof target === 'boolean') {
-    deep = target;
-    target = arguments[1] || {};
-    // skip the boolean and the target
-    i = 2;
-  }
-
-  // Handle case when target is a string or something (possible in deep copy)
-  if (typeof target !== 'object' && !is.fn(target)) {
-    target = {};
-  }
-
-  for (; i < length; i++) {
-    // Only deal with non-null/undefined values
-    options = arguments[i]
-    if (options != null) {
-      if (typeof options === 'string') {
-          options = options.split('');
-      }
-      // Extend the base object
-      for (name in options) {
-        src = target[name];
-        copy = options[name];
-
-        // Prevent never-ending loop
-        if (target === copy) {
-          continue;
-        }
-
-        // Recurse if we're merging plain objects or arrays
-        if (deep && copy && (is.hash(copy) || (copy_is_array = is.array(copy)))) {
-          if (copy_is_array) {
-            copy_is_array = false;
-            clone = src && is.array(src) ? src : [];
-          } else {
-            clone = src && is.hash(src) ? src : {};
-          }
-
-          // Never move original objects, clone them
-          target[name] = extend(deep, clone, copy);
-
-        // Don't bring in undefined values
-        } else if (typeof copy !== 'undefined') {
-          target[name] = copy;
-        }
-      }
-    }
-  }
-
-  // Return the modified object
-  return target;
-};
-
-/**
- * @public
- */
-extend.version = '1.1.3';
-
-/**
- * Exports module.
- */
-module.exports = extend;
-
-
-},{"is":1}],4:[function(require,module,exports){
+},{}],4:[function(require,module,exports){
 (function (global){
 !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),(f.qj||(f.qj={})).js=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
 var QJ, rreturn, rtrim;
@@ -1174,7 +1174,7 @@ Card = (function() {
       validDate: 'valid\nthru',
       monthYear: 'month/year'
     },
-    values: {
+    placeholders: {
       number: '&bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull;',
       cvc: '&bull;&bull;&bull;',
       expiry: '&bull;&bull;/&bull;&bull;',
@@ -1201,12 +1201,12 @@ Card = (function() {
     this.$container = QJ(this.options.container);
     this.render();
     this.attachHandlers();
-    this.handleInitialValues();
+    this.handleInitialPlaceholders();
   }
 
   Card.prototype.render = function() {
     var $cardContainer, baseWidth, name, obj, selector, ua, _ref, _ref1;
-    QJ.append(this.$container, this.template(this.cardTemplate, extend({}, this.options.messages, this.options.values)));
+    QJ.append(this.$container, this.template(this.cardTemplate, extend({}, this.options.messages, this.options.placeholders)));
     _ref = this.options.cardSelectors;
     for (name in _ref) {
       selector = _ref[name];
@@ -1285,7 +1285,7 @@ Card = (function() {
     });
   };
 
-  Card.prototype.handleInitialValues = function() {
+  Card.prototype.handleInitialPlaceholders = function() {
     var el, name, selector, _ref, _results;
     _ref = this.options.formSelectors;
     _results = [];
@@ -1451,7 +1451,7 @@ module.exports = Card;
 global.Card = Card;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"../scss/card.scss":9,"./payment/src/payment.coffee":8,"node.extend":2,"qj":4}],8:[function(require,module,exports){
+},{"../scss/card.scss":9,"./payment/src/payment.coffee":8,"node.extend":1,"qj":4}],8:[function(require,module,exports){
 (function (global){
 var Payment, QJ, cardFromNumber, cardFromType, cards, defaultFormat, formatBackCardNumber, formatBackExpiry, formatCardNumber, formatExpiry, formatForwardExpiry, formatForwardSlash, hasTextSelected, luhnCheck, reFormatCardNumber, restrictCVC, restrictCardNumber, restrictExpiry, restrictNumeric, setCardType,
   __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };

--- a/lib/js/jquery.card.js
+++ b/lib/js/jquery.card.js
@@ -1,4 +1,92 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+module.exports = require('./lib/extend');
+
+
+},{"./lib/extend":2}],2:[function(require,module,exports){
+/*!
+ * node.extend
+ * Copyright 2011, John Resig
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ * http://jquery.org/license
+ *
+ * @fileoverview
+ * Port of jQuery.extend that actually works on node.js
+ */
+var is = require('is');
+
+function extend() {
+  var target = arguments[0] || {};
+  var i = 1;
+  var length = arguments.length;
+  var deep = false;
+  var options, name, src, copy, copy_is_array, clone;
+
+  // Handle a deep copy situation
+  if (typeof target === 'boolean') {
+    deep = target;
+    target = arguments[1] || {};
+    // skip the boolean and the target
+    i = 2;
+  }
+
+  // Handle case when target is a string or something (possible in deep copy)
+  if (typeof target !== 'object' && !is.fn(target)) {
+    target = {};
+  }
+
+  for (; i < length; i++) {
+    // Only deal with non-null/undefined values
+    options = arguments[i]
+    if (options != null) {
+      if (typeof options === 'string') {
+          options = options.split('');
+      }
+      // Extend the base object
+      for (name in options) {
+        src = target[name];
+        copy = options[name];
+
+        // Prevent never-ending loop
+        if (target === copy) {
+          continue;
+        }
+
+        // Recurse if we're merging plain objects or arrays
+        if (deep && copy && (is.hash(copy) || (copy_is_array = is.array(copy)))) {
+          if (copy_is_array) {
+            copy_is_array = false;
+            clone = src && is.array(src) ? src : [];
+          } else {
+            clone = src && is.hash(src) ? src : {};
+          }
+
+          // Never move original objects, clone them
+          target[name] = extend(deep, clone, copy);
+
+        // Don't bring in undefined values
+        } else if (typeof copy !== 'undefined') {
+          target[name] = copy;
+        }
+      }
+    }
+  }
+
+  // Return the modified object
+  return target;
+};
+
+/**
+ * @public
+ */
+extend.version = '1.1.3';
+
+/**
+ * Exports module.
+ */
+module.exports = extend;
+
+
+},{"is":3}],3:[function(require,module,exports){
 
 /**!
  * is
@@ -762,95 +850,7 @@ is.symbol = function (value) {
   return typeof Symbol === 'function' && toStr.call(value) === '[object Symbol]' && typeof symbolValueOf.call(value) === 'symbol';
 };
 
-},{}],2:[function(require,module,exports){
-module.exports = require('./lib/extend');
-
-
-},{"./lib/extend":3}],3:[function(require,module,exports){
-/*!
- * node.extend
- * Copyright 2011, John Resig
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- *
- * @fileoverview
- * Port of jQuery.extend that actually works on node.js
- */
-var is = require('is');
-
-function extend() {
-  var target = arguments[0] || {};
-  var i = 1;
-  var length = arguments.length;
-  var deep = false;
-  var options, name, src, copy, copy_is_array, clone;
-
-  // Handle a deep copy situation
-  if (typeof target === 'boolean') {
-    deep = target;
-    target = arguments[1] || {};
-    // skip the boolean and the target
-    i = 2;
-  }
-
-  // Handle case when target is a string or something (possible in deep copy)
-  if (typeof target !== 'object' && !is.fn(target)) {
-    target = {};
-  }
-
-  for (; i < length; i++) {
-    // Only deal with non-null/undefined values
-    options = arguments[i]
-    if (options != null) {
-      if (typeof options === 'string') {
-          options = options.split('');
-      }
-      // Extend the base object
-      for (name in options) {
-        src = target[name];
-        copy = options[name];
-
-        // Prevent never-ending loop
-        if (target === copy) {
-          continue;
-        }
-
-        // Recurse if we're merging plain objects or arrays
-        if (deep && copy && (is.hash(copy) || (copy_is_array = is.array(copy)))) {
-          if (copy_is_array) {
-            copy_is_array = false;
-            clone = src && is.array(src) ? src : [];
-          } else {
-            clone = src && is.hash(src) ? src : {};
-          }
-
-          // Never move original objects, clone them
-          target[name] = extend(deep, clone, copy);
-
-        // Don't bring in undefined values
-        } else if (typeof copy !== 'undefined') {
-          target[name] = copy;
-        }
-      }
-    }
-  }
-
-  // Return the modified object
-  return target;
-};
-
-/**
- * @public
- */
-extend.version = '1.1.3';
-
-/**
- * Exports module.
- */
-module.exports = extend;
-
-
-},{"is":1}],4:[function(require,module,exports){
+},{}],4:[function(require,module,exports){
 (function (global){
 !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),(f.qj||(f.qj={})).js=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
 var QJ, rreturn, rtrim;
@@ -1174,7 +1174,7 @@ Card = (function() {
       validDate: 'valid\nthru',
       monthYear: 'month/year'
     },
-    values: {
+    placeholders: {
       number: '&bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull;',
       cvc: '&bull;&bull;&bull;',
       expiry: '&bull;&bull;/&bull;&bull;',
@@ -1201,12 +1201,12 @@ Card = (function() {
     this.$container = QJ(this.options.container);
     this.render();
     this.attachHandlers();
-    this.handleInitialValues();
+    this.handleInitialPlaceholders();
   }
 
   Card.prototype.render = function() {
     var $cardContainer, baseWidth, name, obj, selector, ua, _ref, _ref1;
-    QJ.append(this.$container, this.template(this.cardTemplate, extend({}, this.options.messages, this.options.values)));
+    QJ.append(this.$container, this.template(this.cardTemplate, extend({}, this.options.messages, this.options.placeholders)));
     _ref = this.options.cardSelectors;
     for (name in _ref) {
       selector = _ref[name];
@@ -1285,7 +1285,7 @@ Card = (function() {
     });
   };
 
-  Card.prototype.handleInitialValues = function() {
+  Card.prototype.handleInitialPlaceholders = function() {
     var el, name, selector, _ref, _results;
     _ref = this.options.formSelectors;
     _results = [];
@@ -1451,7 +1451,7 @@ module.exports = Card;
 global.Card = Card;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"../scss/card.scss":10,"./payment/src/payment.coffee":9,"node.extend":2,"qj":4}],8:[function(require,module,exports){
+},{"../scss/card.scss":10,"./payment/src/payment.coffee":9,"node.extend":1,"qj":4}],8:[function(require,module,exports){
 var $, Card,
   __slice = [].slice;
 

--- a/src/coffee/card.coffee
+++ b/src/coffee/card.coffee
@@ -63,7 +63,7 @@ class Card
     messages:
       validDate: 'valid\nthru'
       monthYear: 'month/year'
-    values:
+    placeholders:
       number: '&bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull;'
       cvc: '&bull;&bull;&bull;'
       expiry: '&bull;&bull;/&bull;&bull;'
@@ -90,12 +90,12 @@ class Card
 
     @render()
     @attachHandlers()
-    @handleInitialValues()
+    @handleInitialPlaceholders()
 
   render: ->
     QJ.append(@$container, @template(
       @cardTemplate,
-      extend({}, @options.messages, @options.values)
+      extend({}, @options.messages, @options.placeholders)
     ))
 
     for name, selector of @options.cardSelectors
@@ -157,7 +157,7 @@ class Card
         filters: @validToggler('cardHolderName')
         join: ' '
 
-  handleInitialValues: ->
+  handleInitialPlaceholders: ->
     for name, selector of @options.formSelectors
       el = this["$#{name}"]
       if QJ.val(el)


### PR DESCRIPTION
As per issue #185, this pull request changes the name used to refer to the default placeholder values for the card visualisation from 'values' to 'placeholders' and updates the documentation accordingly.

This change should hopefully lead to less confusion as the placeholder values do not work as regular values, and so the distinct naming helps to clarify this. 