### PR TITLE
Add Paribus to list of places that use Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Card is used in the wild in these places:
 * [Sintelle] (http://www.sintelle.fr/)
 * [Wevorce](http://wevorce.com/)
 * [PayumServer](https://github.com/Payum/PayumServer)
+* [Paribus](https://paribus.co)
 
 Are you using Card in production? If so, we'd love to link to you from this page. Open a PR or drop [@jessepollak](http://twitter.com/jessepollak) a line on [Twitter](http://twitter.com/jessepollak) and we'll add you right away!
 


### PR DESCRIPTION
I was using Paribus (a YC company that was on the front page of HN today) and noticed that they were using Card so I added it to the README

![image](https://cloud.githubusercontent.com/assets/4110292/12315979/4bf77326-ba4f-11e5-88d6-ef8d45caa95a.png)
