### PR TITLE
Update .sass to show the back of the card on IE10

### DIFF
--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -42,7 +42,6 @@
 
     &.jp-card-flipped {
         @include transform(rotateY(180deg));
-        @include backface-visibility(hidden);
     }
 
     .jp-card-front, .jp-card-back {


### PR DESCRIPTION
I found that this demo, and where I'm currently testing the card on a website, doesn't show the back of the card due to the visibility being hidden when flipped. When changing this in the dev tools, IE10/Safari, I found that removing the `backface-visibility: hidden` shows the back of the card when entering the security code.