### PR TITLE
Add new rebranding logo for issue #357

### DIFF
--- a/src/coffee/card.coffee
+++ b/src/coffee/card.coffee
@@ -15,8 +15,8 @@ class Card
                 '<div class="l">l</div>' +
                 '<div class="o">o</div>' +
               '</div>' +
-              '<div class="jp-card-logo jp-card-visa">visa</div>' +
-              '<div class="jp-card-logo jp-card-visaelectron">visa<div class="elec">Electron</div></div>' +
+              '<div class="jp-card-logo jp-card-visa">Visa</div>' +
+              '<div class="jp-card-logo jp-card-visaelectron">Visa<div class="elec">Electron</div></div>' +
               '<div class="jp-card-logo jp-card-mastercard">Mastercard</div>' +
               '<div class="jp-card-logo jp-card-maestro">Maestro</div>' +
               '<div class="jp-card-logo jp-card-amex"></div>' +

--- a/src/coffee/card.coffee
+++ b/src/coffee/card.coffee
@@ -23,6 +23,11 @@ class Card
               '<div class="jp-card-logo jp-card-discover">discover</div>' +
               '<div class="jp-card-logo jp-card-dinersclub"></div>' +
               '<div class="jp-card-logo jp-card-dankort"><div class="dk"><div class="d"></div><div class="k"></div></div></div>' +
+              '<div class="jp-card-logo jp-card-jcb">' +
+                '<div class="j">J</div>' +
+                '<div class="c">C</div>' +
+                '<div class="b">B</div>' +
+              '</div>' +
               '<div class="jp-card-lower">' +
                   '<div class="jp-card-shiny"></div>' +
                   '<div class="jp-card-cvc jp-card-display">{{cvc}}</div>' +

--- a/src/coffee/card.coffee
+++ b/src/coffee/card.coffee
@@ -17,7 +17,7 @@ class Card
               '</div>' +
               '<div class="jp-card-logo jp-card-visa">visa</div>' +
               '<div class="jp-card-logo jp-card-visaelectron">visa<div class="elec">Electron</div></div>' +
-              '<div class="jp-card-logo jp-card-mastercard">MasterCard</div>' +
+              '<div class="jp-card-logo jp-card-mastercard">Mastercard</div>' +
               '<div class="jp-card-logo jp-card-maestro">Maestro</div>' +
               '<div class="jp-card-logo jp-card-amex"></div>' +
               '<div class="jp-card-logo jp-card-discover">discover</div>' +

--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -13,6 +13,7 @@
 @import "cards/maestro";
 @import "cards/dankort";
 @import "cards/elo";
+@import "cards/jcb";
 @import "cards/dinersclub";
 
 .jp-card-container {

--- a/src/scss/cards/_jcb.scss
+++ b/src/scss/cards/_jcb.scss
@@ -1,0 +1,18 @@
+@import "card";
+@import "../logos/jcb";
+
+$fill-color: #CB8000;
+
+.jp-card.jp-card-jcb {
+    &.jp-card-identified {
+        .jp-card-front, .jp-card-back {
+            &:before {
+                background-color: $fill-color;
+            }
+        }
+        .jp-card-logo.jp-card-jcb {
+            opacity: 1;
+            box-shadow: none;
+        }
+    }
+}

--- a/src/scss/cards/_visa.scss
+++ b/src/scss/cards/_visa.scss
@@ -12,6 +12,7 @@ $fill-color: #191278;
         }
         .jp-card-logo.jp-card-visa {
             opacity: 1;
+            box-shadow: none;
         }
     }
 }

--- a/src/scss/logos/_jcb.scss
+++ b/src/scss/logos/_jcb.scss
@@ -1,0 +1,45 @@
+@import "logo";
+
+.jp-card-logo.jp-card-jcb {
+    @mixin jcb-radius($jcbradius) {
+      border-radius: $jcbradius 0px $jcbradius 0px;
+      -moz-border-radius: $jcbradius 0px $jcbradius 0px;
+      -webkit-border-radius: $jcbradius 0px $jcbradius 0px;
+    }
+    $logo-padding:2px; $logo-margin:3px;
+    $j-left : #000063; $j-right: #008cff;
+    $c-left : #630000; $c-right: #ff008d;
+    $b-left : #006300; $b-right: #00ff00;
+    
+    
+    font-style:normal;
+    color:white;
+    padding:$logo-padding 0 0 $logo-padding;
+    > div {
+        width: 15px ;
+        margin-right:$logo-margin;
+        display:inline-block;
+        text-align:center;
+        text-shadow:1px 1px rgba(0, 0, 0, 0.6);
+        @include jcb-radius( 5px );
+        &:before, &:after {
+            content: " ";
+            display: block;
+            height: 8px;
+        }
+        
+        &:first-child {
+            margin-left: $logo-padding ;
+        }
+        
+        &.j {
+            @include linear-gradient( to right , $j-left, $j-right);
+        }
+        &.c {
+            @include linear-gradient( to right , $c-left, $c-right);
+        }
+        &.b {
+            @include linear-gradient( to right , $b-left, $b-right);
+        }
+    }
+}

--- a/src/scss/logos/_jcb.scss
+++ b/src/scss/logos/_jcb.scss
@@ -11,13 +11,15 @@
     $c-left : #630000; $c-right: #ff008d;
     $b-left : #006300; $b-right: #00ff00;
     
-    
+    @include jcb-radius( 5px );
+    background-color: white;
     font-style:normal;
     color:white;
+    width:50px;
     padding:$logo-padding 0 0 $logo-padding;
     > div {
         width: 15px ;
-        margin-right:$logo-margin;
+        margin-right:1px;
         display:inline-block;
         text-align:center;
         text-shadow:1px 1px rgba(0, 0, 0, 0.6);
@@ -26,10 +28,6 @@
             content: " ";
             display: block;
             height: 8px;
-        }
-        
-        &:first-child {
-            margin-left: $logo-padding ;
         }
         
         &.j {

--- a/src/scss/logos/_logo.scss
+++ b/src/scss/logos/_logo.scss
@@ -1,5 +1,6 @@
 $logo-height: 36px;
 $logo-width: 60px;
+$mastercard-family-name-height: 84px;
 
 @include exports("_logo.scss") {
     .jp-card-logo {

--- a/src/scss/logos/_maestro.scss
+++ b/src/scss/logos/_maestro.scss
@@ -2,14 +2,16 @@
 
 .jp-card-logo.jp-card-maestro {
     // display: none;
-    $blue: #0064CB;
-    $red: #CC0000;
+    $blue: #EB001B;
+    $red: #00A2E5;
     $offset: 0;
     color: white;
+    font-style: normal;
+    text-transform: lowercase;
     font-weight: bold;
     text-align: center;
     font-size: 14px;
-    line-height: $logo-height;
+    line-height: $mastercard-family-name-height;
     z-index: 1;
     text-shadow: 1px 1px rgba(0, 0, 0, .6);
     &:before, &:after {
@@ -25,12 +27,13 @@
     &:before {
         left: $offset;
         background: $blue;
-        z-index: -1;
+        z-index: -2;
     }
 
     &:after {
         right: $offset;
         background: $red;
-        z-index: -2;
+        z-index: -1;
+        opacity: 0.8;
     }
 }

--- a/src/scss/logos/_mastercard.scss
+++ b/src/scss/logos/_mastercard.scss
@@ -2,14 +2,16 @@
 
 .jp-card-logo.jp-card-mastercard {
     // display: none;
-    $red: #FF0000;
-    $yellow: #FFAB00;
+    $red: #EB001B;
+    $yellow: #FF5F00;
     $offset: 0;
     color: white;
+    font-style: normal;
+    text-transform: lowercase;
     font-weight: bold;
     text-align: center;
     font-size: 9px;
-    line-height: $logo-height;
+    line-height: $mastercard-family-name-height;
     z-index: 1;
     text-shadow: 1px 1px rgba(0, 0, 0, .6);
     &:before, &:after {
@@ -26,6 +28,7 @@
         left: $offset;
         background: $red;
         z-index: -1;
+        opacity: 0.9;
     }
 
     &:after {

--- a/src/scss/logos/_visa.scss
+++ b/src/scss/logos/_visa.scss
@@ -2,15 +2,13 @@
 
 .jp-card-logo.jp-card-visa {
     // display: none;
-    $blue: #1A1876;
-    $yellow: #E79800;
-    background: white;
     text-transform: uppercase;
-    color: $blue;
+    color: white;
     text-align: center;
     font-weight: bold;
-    font-size: 15px;
+    font-size: 24px;
     line-height: 18px;
+    margin-top:5px;
 
 
     &:before, &:after {
@@ -21,10 +19,12 @@
     }
 
     &:before {
-        background: $blue;
-    }
-
-    &:after {
-        background: $yellow;
+        position:absolute;
+        left:-4px;
+        width: 0;
+        height: 0;
+        border-style: solid;
+        border-width: 0 12px 6px 0;
+        border-color: transparent #ffffff transparent transparent;
     }
 }


### PR DESCRIPTION
There're three rebranded logos that plugin still using old logo yet: Visa, Mastercard, and Maestro. For these three, I just made some commits.

This plugin is great by the way.

Logo guideline reference:
For Visa: https://usa.visa.com/dam/VCOM/download/merchants/New_VBM_Acq_Merchant_62714_v5.pdf
For Mastercard and Maestro: https://brand.mastercard.com