### PR TITLE
Fix Mobile-Responsive breaking layout

### DIFF
--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -291,3 +291,16 @@
     }
   }
 }
+
+@media (max-width: 450px) {
+  .card-wrapper {
+    max-width: 80vw;
+    width: 100%;
+    margin: 20px auto;
+    overflow-x: hidden;
+    & > .jp-card-container {
+      transform: scale(0.625);
+      transform-origin: left center;
+    }
+  }
+}


### PR DESCRIPTION
Issue Reference: #463 
On devices with width less than 450px, the layout corrupts and the card goes "outside" of the screen. This is fixed in this commit