### PR TITLE
Feat: Card type func() and event is fired when card type changes

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,10 +1,12 @@
 ﻿<!DOCTYPE html>
 <html>
+
 <head>
     <title>Card &ndash; the better way to collect credit cards</title>
     <meta name="viewport" content="initial-scale=1">
     <!-- CSS is included through the card.js script -->
 </head>
+
 <body>
     <style>
         .demo-container {
@@ -16,12 +18,12 @@
         form {
             margin: 30px;
         }
+
         input {
             width: 200px;
             margin: 10px auto;
             display: block;
         }
-
     </style>
     <div class="demo-container">
         <div class="card-wrapper"></div>
@@ -38,10 +40,11 @@
 
     <script src="http://localhost:8080/card.js"></script>
     <script>
-        new Card({
+        var c = new Card({
             form: document.querySelector('form'),
             container: '.card-wrapper'
         });
     </script>
 </body>
+
 </html>

--- a/src/coffee/card.coffee
+++ b/src/coffee/card.coffee
@@ -300,7 +300,7 @@ class Card
 
   getCardType: ->
     ccType = Payment.fns.cardType(@$numberInput[0].value)
-    if ccType then Payment.fns.cardType(@$numberInput[0].value) else 'unknown'
+    if ccType then ccType else 'unknown'
 
 
 module.exports = Card

--- a/src/coffee/card.coffee
+++ b/src/coffee/card.coffee
@@ -239,6 +239,8 @@ class Card
   handlers:
     setCardType: ($el, e) ->
       cardType = e.data
+      event = new CustomEvent('card-type-changed', 'detail': e.data)
+      document.dispatchEvent event
       unless QJ.hasClass @$card, cardType
         QJ.removeClass @$card, 'jp-card-unknown'
         QJ.removeClass @$card, @cardTypes.join(' ')
@@ -295,6 +297,10 @@ class Card
         outVal = val or outDefaults[i]
 
       outEl.textContent = outVal
+
+  getCardType: ->
+    ccType = Payment.fns.cardType(@$numberInput[0].value)
+    if ccType then Payment.fns.cardType(@$numberInput[0].value) else 'unknown'
 
 
 module.exports = Card


### PR DESCRIPTION
#412
- Added a getCardType() func. which returns the card type as a string.
```javascript
var c = new Card({
            form: document.querySelector('form'),
            container: '.card-wrapper'
        });
c.getCardType();
```
> "visa" 
- Also a CustomEvent is fired to the DOM when the card type changes.
```javascript
document.addEventListener('card-type-changed', (e) => console.log(e.detail));
```
> "visa"